### PR TITLE
Update git clone URL in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ OR
 
 Clone the DiffCDISC repository onto your local filesystem using Git:
 
-C:\> git clone https://github.com/NCIEVS/nci-diff-CDISC.git
+C:\> git clone https://github.com/NCIP/nci-diff-CDISC.git
 
 Open a Command Prompt and navigate to the repository directory.
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ OR
 
 Clone the DiffCDISC repository onto your local filesystem using Git:
 
-C:\> git clone https://github.com/NCIEVS/diff-cdisc.git
+C:\> git clone https://github.com/NCIEVS/nci-diff-CDISC.git
 
 Open a Command Prompt and navigate to the repository directory.
 


### PR DESCRIPTION
This previously instructed the user to point to the NCIEVS repo, and the repo name was also incorrect.  This now points the user to the public facing git repo on NCIP.